### PR TITLE
Use HTTPS for downloading curl script

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -74,7 +74,7 @@ mkdir -p $(dirname $PROFILE_PATH)
 CONDA_VERSION=3.10.1
 if [ ! -d /app/.heroku/miniconda ]; then
   puts-step "Preparing Python Environment (${CONDA_VERSION})"
-  curl -Os http://repo.continuum.io/miniconda/Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
+  curl -Os https://repo.continuum.io/miniconda/Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
   bash Miniconda-${CONDA_VERSION}-Linux-x86_64.sh -p /app/.heroku/miniconda/ -b | indent
   rm -fr Miniconda-${CONDA_VERSION}-Linux-x86_64.sh
 


### PR DESCRIPTION
It's already available over HTTPS, so this should Just Work, and improve the security of the installation process.
